### PR TITLE
Make plugin compatible to Jenkins Pipeline plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580.1</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.642.3</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <groupId>org.biouno.r</groupId>
@@ -214,4 +214,11 @@
   	</pluginManagement>
   </build>
   
+  <dependencies>
+      <dependency>
+          <groupId>org.jenkins-ci.plugins.workflow</groupId>
+          <artifactId>workflow-durable-task-step</artifactId>
+          <version>2.4</version>
+      </dependency>
+  </dependencies>
 </project>

--- a/src/main/java/org/biouno/r/RStep.java
+++ b/src/main/java/org/biouno/r/RStep.java
@@ -1,0 +1,73 @@
+package org.biouno.r;
+
+import hudson.Extension;
+import hudson.FilePath;
+import org.jenkinsci.plugins.durabletask.BourneShellScript;
+import org.jenkinsci.plugins.durabletask.DurableTask;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep;
+import org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.DurableTaskStepDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class RStep extends DurableTaskStep {
+
+    private static final String R_EXECUTABLE = "Rscript";
+    private static final String FILE_PREFIX = "jenkins";
+    private static final String FILE_EXTENSION = ".R";
+
+    @StepContextParameter private FilePath ws;
+
+    private final String command;
+
+    @DataBoundConstructor
+    public RStep(String command) {
+        this.command = checkNotNull(command, Messages.R_NullCommandError());
+    }
+
+    /**
+     * Returns the set R command to execute
+     * 
+     * @return the R command to execute
+     */
+    public String getCommand() {
+        return command;
+    }
+
+    @Override
+    protected DurableTask task() {
+        
+        String shellScript = getShellScriptExecutingRScript();
+        return new BourneShellScript(shellScript);
+    }
+
+    private String getShellScriptExecutingRScript() {
+        try {
+            FilePath rScript = ws.createTextTempFile(FILE_PREFIX, FILE_EXTENSION, command, false);
+            return R_EXECUTABLE + " " + rScript.getRemote();
+        } catch (IOException e) {
+            throw new IllegalStateException(Messages.R_FileCreationError(), e);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException(Messages.R_FileCreationError(), e);
+        }
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends DurableTaskStepDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.R_DisplayName();
+        }
+
+        @Override
+        public String getFunctionName() {
+            return Messages.R_FunctionName();
+        }
+
+    }
+
+}

--- a/src/main/resources/org/biouno/r/Messages.properties
+++ b/src/main/resources/org/biouno/r/Messages.properties
@@ -1,1 +1,4 @@
 R.DisplayName=Execute R script
+R.FunctionName=rscript
+R.FileCreationError=Could not create R script temporary file.
+R.NullCommandError=R command can not be null.

--- a/src/main/resources/org/biouno/r/RStep/config-details.jelly
+++ b/src/main/resources/org/biouno/r/RStep/config-details.jelly
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Script}" field="command">
+        <f:textarea class="codemirror fixed-width" codemirror-config="mode: 'text/x-rsrc'"
+                    codemirror-mode="r" />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/biouno/r/RStep/help-script.html
+++ b/src/main/resources/org/biouno/r/RStep/help-script.html
@@ -1,0 +1,7 @@
+<div>
+    <p>
+        Runs an R script (defaults to <tt>Rscript</tt> interpreter) for 
+        building the project.
+        The script will be run with the workspace as the current directory.
+    </p>
+</div>


### PR DESCRIPTION
A simple implementation of `SimpleBuildStep`. Creating a dummy `FreeStyleBuild` and only setting properties which are needed by `CommandInterpreter#perform(AbstractBuild, Launcher, TaskListener)`.
