### PR TITLE
[WIP] Create R script file in workspace

### DIFF
--- a/src/main/java/org/biouno/r/RStep.java
+++ b/src/main/java/org/biouno/r/RStep.java
@@ -79,7 +79,7 @@ public class RStep extends DurableTaskStep {
 
         private static String getShellScriptExecutingRScript(FilePath ws, String command) {
             try {
-                FilePath rScript = ws.createTextTempFile(FILE_PREFIX, FILE_EXTENSION, command, false);
+                FilePath rScript = ws.createTextTempFile(FILE_PREFIX, FILE_EXTENSION, command, true);
                 return R_EXECUTABLE + " " + rScript.getRemote();
             } catch (IOException e) {
                 throw new IllegalStateException(Messages.R_FileCreationError(), e);


### PR DESCRIPTION
Trying to use the `r` step inside a docker container step (like `withDockerContainer`) in a pipeline script failed because the R script file was created inside the `/tmp` folder of the jenkins node instead of the docker container. The `/tmp` folder is not bound to the docker container as a volume by default, but the project workspace is.